### PR TITLE
Issue 10 - Add CodeCov integration support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+source = .
+
+[report]
+omit = avtozip/avtozip/settings.py,env/*
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
-Project for AutoZip backend API and admin
+Project for AvtoZip backend API and admin
 
 [![Circle CI](https://circleci.com/gh/AvtoZip/api-avtozip.svg?style=svg)](https://circleci.com/gh/AvtoZip/api-avtozip)
+[![codecov.io](https://codecov.io/github/AvtoZip/api-avtozip/coverage.svg?branch=master)](https://codecov.io/github/AvtoZip/api-avtozip?branch=master)

--- a/circle.yml
+++ b/circle.yml
@@ -15,4 +15,5 @@ dependencies:
 test:
   override:
     - flake8 --statistics avtozip/
-    - python avtozip/manage.py test
+    - coverage run --branch avtozip/manage.py test
+    - codecov --token=f78171d5-9f65-42b1-8967-2501724c89ae

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+codecov==1.6.3
 flake8-blind-except==0.1.0
 flake8-deprecated==1.0
 flake8-import-order==0.7


### PR DESCRIPTION
CodeCov support has been added but unfortunately it has been added to `circleci.yml` file in test override section which will be executed even if tests fail. In upcoming commit this flaw will be fixed with custom `Makefile` approach and different targets
Additionals:
- Added CodeCov badge to readme file
- Added `.coveragerc` configuration file

Fixes #10 

@zitoss please take a look
