### PR TITLE
Issue 12 - Add Build status page to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 Project for AutoZip backend API and admin
+
+[![Circle CI](https://circleci.com/gh/AvtoZip/api-avtozip.svg?style=svg)](https://circleci.com/gh/AvtoZip/api-avtozip)


### PR DESCRIPTION
Build status badge for `default` branch has been added to `README.md` file

Fixes #12

@zitoss just FYI
