### PR TITLE
Issue 19 - Add Makefile to the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,73 @@
+.PHONY: build clean devserver fasttest install install-py \
+        lint manage migrate server shell test
+
+# Project settings
+PROJECT = avtozip
+
+# Virtual environment settings
+ENV ?= ./env
+REQUIREMENTS ?= -r requirements-dev.txt
+
+# Python commands
+COVERAGE = coverage
+FLAKE8 = flake8
+GUNICORN = gunicorn
+PYTHON = python
+
+# Gunicorn settings
+GUNICORN_NAME ?= avtozip
+GUNICORN_WORKERS ?= $(shell python -c "import multiprocessing; print(multiprocessing.cpu_count() * 2 + 1);")
+LOGS_DIR ?= ./logs
+SERVER_HOST ?= 0.0.0.0
+SERVER_PORT ?= 8012
+
+# Other settings
+DJANGO_SERVER ?= runserver
+DJANGO_SHELL ?= shell_plus
+
+all: install build
+
+build: migrate
+
+clean:
+ifeq ($(CIRCLECI),)
+	find ./$(PROJECT) $(ENV) \( -name "*.pyc" -o -type d -empty \) -exec rm -rf {} +
+endif
+
+devserver: clean
+	COMMAND="$(DJANGO_SERVER) $(SERVER_HOST):$(SERVER_PORT)" $(MAKE) manage
+
+fasttest:
+	REUSE_DB=1 $(MAKE) test
+
+install: install-github-key install-py
+
+install-github-key:
+	ssh-keygen -H -F github.com > /dev/null || ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+
+install-py:
+ifeq ($(CIRCLECI),)
+	[ ! -d "$(ENV)/" ] && virtualenv $(ENV)/ || :
+	$(ENV)/bin/pip install $(REQUIREMENTS)
+else
+	pip install $(REQUIREMENTS)
+endif
+
+lint:
+	$(FLAKE8) --statistics ./$(PROJECT)/
+
+manage:
+	$(PYTHON) ./$(PROJECT)/manage.py $(COMMAND)
+
+migrate:
+	COMMAND="migrate --noinput" $(MAKE) manage
+
+server: clean lint
+	PYTHONPATH=$(PROJECT) $(GUNICORN) -b $(SERVER_HOST):$(SERVER_PORT) -w $(GUNICORN_WORKERS) -n $(GUNICORN_NAME) -t 60 --graceful-timeout 60 $(gunicorn_args) $(GUNICORN_ARGS) $(PROJECT).wsgi:application
+
+shell:
+	COMMAND=$(DJANGO_SHELL) $(MAKE) manage
+
+test: clean lint
+	$(COVERAGE) run --branch ./$(PROJECT)/manage.py test $(TEST_ARGS)
+	$(COVERAGE) report

--- a/avtozip/avtozip/settings.py
+++ b/avtozip/avtozip/settings.py
@@ -30,6 +30,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
+    'django_extensions',
     'tastypie',
 
     'store',

--- a/circle.yml
+++ b/circle.yml
@@ -10,10 +10,9 @@ machine:
 
 dependencies:
   override:
-    - pip install -r requirements.txt -r requirements-dev.txt
+    - make install
 
 test:
   override:
-    - flake8 --statistics avtozip/
-    - coverage run --branch avtozip/manage.py test
+    - make test
     - codecov --token=f78171d5-9f65-42b1-8967-2501724c89ae

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+-r requirements.txt
+
 codecov==1.6.3
 flake8-blind-except==0.1.0
 flake8-deprecated==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dj-database-url==0.4.0
 Django==1.9.4
+django-extensions==1.6.1
 django-tastypie==0.13.3
 psycopg2==2.6.1


### PR DESCRIPTION
Added makefile with the following targets:
- **build**: run `migrate`
- **clean**: cleaning all *.pyc files
- **devserver**: run `clean` and django development server
- **fasttest**: run `test` with `REUSE_DB=1`
- **install**: run `install-github-key` and `install-py`
- **install-github-key**: install github-related SSH keys and add them to known_hosts
- **install-py**: activating virtualenv and installing requirements files
- **lint**: checking the project with flakes8
- **manage**: ordinary django manage script
- **server**: run `clean`, `lint` and run server using `gunicorn` web server
- **shell**: run enhanced django shell `shell_plus`
- **test**: run `clean`, `lint` and run tests with coverage

Temporary changed solution to install only `requirements-dev.txt` which installs `requirements.txt` from inside (for future enhancement)
Added `django_extensions` for better usage of wide amount of manage commands
Updated `circleci.yml` file to use added `make` command

@zitoss , @Gosha2015 please take a look

Fixes #19
