### PR TITLE
Issue 21 - Add descriptive string representation for Product model

### DIFF
--- a/avtozip/store/models.py
+++ b/avtozip/store/models.py
@@ -28,3 +28,9 @@ class Product(models.Model):
     cost = models.DecimalField(max_digits=10, decimal_places=2)
     price = models.DecimalField(max_digits=10, decimal_places=2)
     count = models.DecimalField(max_digits=10, decimal_places=2)
+
+    def __str__(self):
+        """String representation of product model."""
+        return '<{model_name}#{id} ({article}): {name}>'.format(
+            model_name=self.__class__.__name__, id=self.id, article=self.article, name=self.name,
+        )

--- a/avtozip/store/tests/test_models.py
+++ b/avtozip/store/tests/test_models.py
@@ -4,7 +4,10 @@ from autofixture import AutoFixture
 
 from django.test import TestCase
 
-from ..models import ProductCategory
+from ..models import (
+    Product,
+    ProductCategory,
+)
 
 
 class ModelRepresentationTestCase(TestCase):
@@ -13,7 +16,16 @@ class ModelRepresentationTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):  # NOQA
         """Class based setup."""
-        AutoFixture(ProductCategory).create()
+        AutoFixture(Product, generate_fk=True).create()
+
+    def test_product_representation(self):
+        """Test for product representation."""
+        product = Product.objects.first()
+        result = '{0}'.format(product)
+        self.assertIn(product.__class__.__name__, result)
+        self.assertIn(str(product.id), result)
+        self.assertIn(product.article, result)
+        self.assertIn(product.name, result)
 
     def test_product_category_representation(self):
         """Test for product category representation."""


### PR DESCRIPTION
- Add descriptive representation of Product model by `__str__` magic method

@sshishov please look at the code.

Fixes #21
