### PR TITLE
Issue 24 - Divide settings into different categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ target/
 
 # Custom IGNORES
 .idea/
+
+# Settings
+/avtozip/avtozip/settings/local.py

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 .PHONY: build clean devserver fasttest install install-py \
-        lint manage migrate server shell test
+		lint manage migrate server shell test
 
 # Project settings
+LEVEL ?= development
 PROJECT = avtozip
 
 # Virtual environment settings
 ENV ?= ./env
-REQUIREMENTS ?= -r requirements-dev.txt
+ifeq ($(LEVEL),development)
+	REQUIREMENTS = -r requirements-dev.txt
+else:
+	REQUIREMENTS = -r requirements.txt
+endif
 
 # Python commands
 COVERAGE = coverage
@@ -22,9 +27,9 @@ SERVER_HOST ?= 0.0.0.0
 SERVER_PORT ?= 8012
 
 # Other settings
-DJANGO_SERVER ?= runserver
-DJANGO_SHELL ?= shell_plus
-TEST_ARGS = avtozip
+DJANGO_SERVER = runserver
+DJANGO_SHELL = shell_plus
+TEST_ARGS ?= avtozip
 
 all: install build
 
@@ -55,7 +60,9 @@ else
 endif
 
 lint:
+ifeq ($(LEVEL),development)
 	$(FLAKE8) --statistics ./$(PROJECT)/
+endif
 
 manage:
 	$(PYTHON) ./$(PROJECT)/manage.py $(COMMAND)

--- a/avtozip/avtozip/settings/__init__.py
+++ b/avtozip/avtozip/settings/__init__.py
@@ -1,0 +1,1 @@
+"""Package to contain different settings development/production etc."""

--- a/avtozip/avtozip/settings/development.py
+++ b/avtozip/avtozip/settings/development.py
@@ -1,0 +1,22 @@
+"""Django development settings to override production."""
+
+from ..utils import inject_settings
+
+
+# Default values for overriden settings
+INSTALLED_APPS = []
+
+# Inject default settings to avoid wildcard import
+inject_settings('avtozip.settings.production', locals())
+
+# Debug settings
+DEBUG = True
+ALLOWED_HOSTS = []
+
+# Django TastyPie settings
+TASTYPIE_DEFAULT_FORMATS = ['json']
+
+# Additional applications
+INSTALLED_APPS += [
+    'debug_toolbar',
+]

--- a/avtozip/avtozip/settings/local.py.tmpl
+++ b/avtozip/avtozip/settings/local.py.tmpl
@@ -1,0 +1,6 @@
+"""Module for user-based local overrides of settings (template)."""
+
+from ..utils import inject_settings
+
+
+inject_settings('avtozip.settings.development', locals())

--- a/avtozip/avtozip/settings/production.py
+++ b/avtozip/avtozip/settings/production.py
@@ -1,4 +1,4 @@
-"""Django settings for avtozip project."""
+"""Django production settings."""
 
 import os
 
@@ -7,21 +7,14 @@ import dj_database_url
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
-
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'kknfrz7qvs%fr(yfui8iuds0pk%a2a0xbux1+i%54eb$^1rf^h'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-ALLOWED_HOSTS = []
-
+DEBUG = False
+ALLOWED_HOSTS = ['127.0.0.1']
 
 # Application definition
-
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
@@ -35,7 +28,6 @@ INSTALLED_APPS = [
 
     'store',
 ]
-
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -46,9 +38,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
-
 ROOT_URLCONF = 'avtozip.urls'
-
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -66,13 +56,10 @@ TEMPLATES = [
         },
     },
 ]
-
 WSGI_APPLICATION = 'avtozip.wsgi.application'
-
 
 # Database
 # https://docs.djangoproject.com/en/1.9/ref/settings/#databases
-
 DATABASE_URL = os.environ.get(
     'DATABASE_URL',
     '{schema}://{username}:{password}@{hostname}:{port}/{database}'.format(
@@ -88,10 +75,8 @@ DATABASES = {
     'default': dj_database_url.parse(DATABASE_URL)
 }
 
-
 # Password validation
 # https://docs.djangoproject.com/en/1.9/ref/settings/#auth-password-validators
-
 AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
@@ -107,26 +92,14 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-# Django TastyPie settings
-
-TASTYPIE_DEFAULT_FORMATS = ['json']
-
-
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/
-
 LANGUAGE_CODE = 'en-us'
-
 TIME_ZONE = 'UTC'
-
 USE_I18N = True
-
 USE_L10N = True
-
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
-
 STATIC_URL = '/static/'

--- a/avtozip/avtozip/tests/__init__.py
+++ b/avtozip/avtozip/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Testing package for AvtoZip project related stuff."""

--- a/avtozip/avtozip/tests/test_utils.py
+++ b/avtozip/avtozip/tests/test_utils.py
@@ -1,0 +1,37 @@
+"""Testing module for Store application models."""
+
+from django.test import TestCase
+
+from ..utils import inject_settings
+
+
+class InjectorTestCase(TestCase):
+    """Inject settings testcases."""
+
+    @classmethod
+    def setUpTestData(cls):  # NOQA
+        """Setup class based test data."""
+        cls.context = {'DEBUG': None}
+
+    def test_inject_production_success(self):
+        """Success for production settings."""
+        context = self.context.copy()
+        inject_settings('avtozip.settings.production', context)
+        self.assertEqual(context['DEBUG'], False)
+
+    def test_inject_development_success(self):
+        """Success for development settings."""
+        context = self.context.copy()
+        inject_settings('avtozip.settings.development', context)
+        self.assertEqual(context['DEBUG'], True)
+
+    def test_inject_local_failure(self):
+        """Failure for local settings."""
+        context = self.context.copy()
+        self.assertRaises(ImportError, *(inject_settings, 'avtozip.settings.local', context))
+
+    def test_inject_local_failure_silent(self):
+        """Failure for local settings with silent error handling."""
+        context = self.context.copy()
+        inject_settings('avtozip.settings.local', context, fail_silently=True)
+        self.assertEqual(context['DEBUG'], None)

--- a/avtozip/avtozip/tests/test_views.py
+++ b/avtozip/avtozip/tests/test_views.py
@@ -1,0 +1,14 @@
+"""Testing module for views of AvtoZip project."""
+
+from django.template.exceptions import TemplateDoesNotExist
+from django.test import TestCase
+
+from ..views import dashboard_view
+
+
+class DashboardViewTestCase(TestCase):
+    """Dashboard page tests of AvtoZip project."""
+
+    def test_direct_access(self):
+        """Test direct access of the view."""
+        self.assertRaises(TemplateDoesNotExist, *(dashboard_view, self.client.request))

--- a/avtozip/avtozip/utils.py
+++ b/avtozip/avtozip/utils.py
@@ -1,0 +1,21 @@
+"""Utilites for general project point."""
+
+from importlib import import_module
+
+
+def inject_settings(path, context, fail_silently=False):
+    """Inject settings from module at path to the given context.
+
+    Do not raise an Import Error when fail silently enabled.
+    """
+    try:
+        module = import_module(path)
+    except ImportError:
+        if fail_silently:
+            return
+        raise
+
+    for attr in dir(module):
+        if attr[0] == '_' or not attr.isupper():
+            continue
+        context[attr] = getattr(module, attr)

--- a/avtozip/manage.py
+++ b/avtozip/manage.py
@@ -6,8 +6,7 @@ import os
 import sys
 
 if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'avtozip.settings')
-
+    level = os.environ.get('LEVEL') or 'development'
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'avtozip.settings.{0}'.format(level))
     from django.core.management import execute_from_command_line
-
     execute_from_command_line(sys.argv)

--- a/avtozip/store/api/tests/__init__.py
+++ b/avtozip/store/api/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Store application REST API."""

--- a/avtozip/store/api/tests/test_base_resource.py
+++ b/avtozip/store/api/tests/test_base_resource.py
@@ -1,0 +1,19 @@
+"""Tests for StoreBaseResource functionality."""
+
+from django.test import TestCase
+
+from tastypie import http
+
+
+class GetSchemaTestCase(TestCase):
+    """Forbidden schema access for any resource."""
+
+    def test_product(self):
+        """Test ProductResource."""
+        response = self.client.get('/api/store_v1/product/schema/')
+        self.assertEqual(response.status_code, http.HttpForbidden.status_code)
+
+    def test_product_category(self):
+        """Test ProductCategoryResource."""
+        response = self.client.get('/api/store_v1/productcategory/schema/')
+        self.assertEqual(response.status_code, http.HttpForbidden.status_code)

--- a/avtozip/store/api/tests/test_product.py
+++ b/avtozip/store/api/tests/test_product.py
@@ -1,0 +1,1 @@
+"""Test ProductResource functionality."""

--- a/avtozip/store/api/tests/test_product_category.py
+++ b/avtozip/store/api/tests/test_product_category.py
@@ -1,0 +1,1 @@
+"""Test ProductCategoryResource functionality."""

--- a/avtozip/store/tests/test_views.py
+++ b/avtozip/store/tests/test_views.py
@@ -1,0 +1,14 @@
+"""Testing module for views of Store application."""
+
+from django.template.exceptions import TemplateDoesNotExist
+from django.test import TestCase
+
+from ..views import index_view
+
+
+class IndexViewTestCase(TestCase):
+    """Index page tests of Store application."""
+
+    def test_direct_access(self):
+        """Test direct access of the view."""
+        self.assertRaises(TemplateDoesNotExist, *(index_view, self.client.request))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 
 codecov==1.6.3
 django-autofixture==0.12.0
+django-debug-toolbar==1.4
 flake8-blind-except==0.1.0
 flake8-deprecated==1.0
 flake8-import-order==0.7


### PR DESCRIPTION
Different settings categories have been created:
- production (for production usage - general settings)
- development (for development usage with common dev parameters and `DEBUG=True`
- local (not under git, only template is available) for local overrides

By default `development` level is used everywhere.
On production 'production' level will be set in future

Added some tests for project's `utils` module

Updated `.gitignore` with appropriate records
Updated `Makefile` to include setting's `LEVEL` configuration dependance
Added `django-debug-toolbar` to dev requirements

@zitoss , @Gosha2015  please take a look

Fixes #24
