### PR TITLE
Issue 41 - Add Coveralls integration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{.babelrc,.eslintrc,bower.json,package.json}]
+indent_size = 2
+
+[*.{html,js,py,scss}]
+indent_size = 4
+
+[*.yml]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+tab_width = 4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-Project for AvtoZip backend API and admin
+# Project for AvtoZip backend API and admin
 
+## Badges
 [![Circle CI](https://circleci.com/gh/AvtoZip/api-avtozip.svg?style=shield)](https://circleci.com/gh/AvtoZip/api-avtozip)
-[![codecov.io](https://codecov.io/github/AvtoZip/api-avtozip/coverage.svg?branch=master)](https://codecov.io/github/AvtoZip/api-avtozip?branch=master)
+[![codecov.io](https://codecov.io/github/AvtoZip/api-avtozip/coverage.svg)](https://codecov.io/github/AvtoZip/api-avtozip)
+[![Coverage Status](https://coveralls.io/repos/github/AvtoZip/api-avtozip/badge.svg)](https://coveralls.io/github/AvtoZip/api-avtozip)

--- a/circle.yml
+++ b/circle.yml
@@ -15,4 +15,6 @@ dependencies:
 test:
   override:
     - make test
+  post:
     - codecov --token=f78171d5-9f65-42b1-8967-2501724c89ae
+    - COVERALLS_REPO_TOKEN=bn2H57C5PkRsEF6JKHQidjxMQLsMwlGzO coveralls

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 
 codecov==1.6.3
+coveralls==1.1
 django-autofixture==0.12.0
 django-debug-toolbar==1.4
 flake8-blind-except==0.1.0


### PR DESCRIPTION
`Coveralls` code coverage tool will be integrated to our repo to compare with `CodeCov`.
Added `.editorconfig`
Added `coveralls` to circle configuration file
Added `coveralls` to dev requirements

@zitoss , @Gosha2015  please take a look

Fixes #41
