### PR TITLE
Issue 51 - Add proxy to TecDoc web service

### DIFF
--- a/avtozip/avtozip/settings/development.py
+++ b/avtozip/avtozip/settings/development.py
@@ -21,3 +21,6 @@ INSTALLED_APPS += [
     'debug_toolbar',
     'rosetta',
 ]
+
+# Proxy settings
+PROXY_TECDOC_URL = 'http://localhost:8013/api/tecdoc_v1'

--- a/avtozip/avtozip/settings/production.py
+++ b/avtozip/avtozip/settings/production.py
@@ -24,6 +24,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 
     'django_extensions',
+    'httpproxy',
     'tastypie',
 
     'store',
@@ -118,3 +119,6 @@ DEFAULT_SKIPPED_LOCALES = ['en']
 STATIC_URL = '/static/'
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+
+# Proxy settings
+PROXY_TECDOC_URL = 'http://tecdoc.avtozip.ru/api/tecdoc_v1'

--- a/avtozip/avtozip/urls.py
+++ b/avtozip/avtozip/urls.py
@@ -1,7 +1,10 @@
 """avtozip URL Configuration."""
 
+from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
+
+from httpproxy.views import HttpProxy
 
 from store.api.urls import store_api
 
@@ -15,4 +18,5 @@ urlpatterns = [
     url(r'^store/', include('store.urls', namespace='store')),
     url(r'^rosetta/', include('rosetta.urls')),
     url(r'^i18n/', include('django.conf.urls.i18n')),
+    url(r'^tecdoc/(?P<url>.*)$', HttpProxy.as_view(base_url=settings.PROXY_TECDOC_URL)),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 dj-database-url==0.4.0
 Django==1.9.4
 django-extensions==1.6.1
+django-http-proxy==0.4.3
 django-tastypie==0.13.3
 psycopg2==2.6.1


### PR DESCRIPTION
3rd party application has been added to provide proxy access (django-http-proxy)
General urls have been updated to support `^tecdoc/...` url pattern to redirect to PROXY_TECDOC_URL configured in settings)
Different settings are applied for production and for development

@zitoss , @youshal please review

Fixes #51 
