### PR TITLE
Issue 43 - Add localization support for EN/RU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ target/
 
 # Custom IGNORES
 .idea/
+.DS_Store
 avtozip/static/
 
 # Settings

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build clean devserver fasttest install install-py \
-		lint manage migrate server shell test
+		lint manage messages migrate server shell test
 
 # Project settings
 LEVEL ?= development
@@ -29,7 +29,7 @@ SERVER_PORT ?= 8012
 # Other settings
 DJANGO_SERVER = runserver
 DJANGO_SHELL = shell_plus
-TEST_ARGS ?= avtozip
+TEST_ARGS ?= $(PROJECT)
 TEST_PROCESSES ?= 4
 
 all: install build
@@ -61,7 +61,11 @@ ifeq ($(LEVEL),development)
 endif
 
 manage:
-	$(PYTHON) ./$(PROJECT)/manage.py $(COMMAND)
+	cd $(PROJECT) && $(PYTHON) ./manage.py $(COMMAND)
+
+messages:
+	COMMAND="makemessages --locale en --locale ru -v 1" $(MAKE) manage
+	COMMAND="compilemessages --locale en --locale ru -v 1" $(MAKE) manage
 
 migrate:
 	COMMAND="migrate --noinput" $(MAKE) manage

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-.PHONY: build clean devserver fasttest install install-py \
-		lint manage messages migrate server shell test
+.PHONY: build checkmessages clean devserver fasttest install install-py lint manage messages migrate server \
+		shell test
 
 # Project settings
 LEVEL ?= development
@@ -35,6 +35,9 @@ TEST_PROCESSES ?= 4
 all: install build
 
 build: migrate
+
+checkmessages:
+	COMMAND="checkmessages --verbosity 3" $(MAKE) manage
 
 clean:
 ifeq ($(CIRCLECI),1)
@@ -76,7 +79,7 @@ server: clean lint
 shell:
 	COMMAND=$(DJANGO_SHELL) $(MAKE) manage
 
-test: clean lint
+test: clean lint checkmessages
 	$(COVERAGE) erase
 	$(COVERAGE) run $(PROJECT)/manage.py test $(TEST_ARGS)
 	$(COVERAGE) combine

--- a/avtozip/avtozip/settings/development.py
+++ b/avtozip/avtozip/settings/development.py
@@ -19,4 +19,5 @@ TASTYPIE_DEFAULT_FORMATS = ['json']
 # Additional applications
 INSTALLED_APPS += [
     'debug_toolbar',
+    'rosetta',
 ]

--- a/avtozip/avtozip/settings/production.py
+++ b/avtozip/avtozip/settings/production.py
@@ -37,6 +37,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
 ]
 ROOT_URLCONF = 'avtozip.urls'
 TEMPLATES = [
@@ -102,6 +103,15 @@ TIME_ZONE = 'UTC'
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True
+LANGUAGES = (
+    ('en', 'English'),
+    ('ru', 'Russian'),
+)
+LOCALE_PATHS = (
+    os.path.join(BASE_DIR, 'locales'),
+)
+DEFAULT_EXTRA_KEYWORDS = ['_u', '_ul']
+DEFAULT_SKIPPED_LOCALES = ['en']
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/

--- a/avtozip/avtozip/urls.py
+++ b/avtozip/avtozip/urls.py
@@ -13,4 +13,6 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include(store_api.urls)),
     url(r'^store/', include('store.urls', namespace='store')),
+    url(r'^rosetta/', include('rosetta.urls')),
+    url(r'^i18n/', include('django.conf.urls.i18n')),
 ]

--- a/avtozip/locales/en/LC_MESSAGES/django.po
+++ b/avtozip/locales/en/LC_MESSAGES/django.po
@@ -1,0 +1,102 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-18 13:38+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: store/models.py:10
+msgid "Line1"
+msgstr ""
+
+#: store/models.py:11
+msgid "Line2"
+msgstr ""
+
+#: store/models.py:12
+msgid "Street"
+msgstr ""
+
+#: store/models.py:13
+msgid "City"
+msgstr ""
+
+#: store/models.py:14
+msgid "State"
+msgstr ""
+
+#: store/models.py:15
+msgid "ZIP"
+msgstr ""
+
+#: store/models.py:16
+msgid "Country"
+msgstr ""
+
+#: store/models.py:33 store/models.py:49 store/models.py:63
+msgid "Name"
+msgstr ""
+
+#: store/models.py:62
+msgid "Article"
+msgstr ""
+
+#: store/models.py:65
+msgid "Cost"
+msgstr ""
+
+#: store/models.py:66
+msgid "Price"
+msgstr ""
+
+#: store/models.py:67
+msgid "Count"
+msgstr ""
+
+#: store/models.py:68
+msgid "Active"
+msgstr ""
+
+#: store/templates/store/index.html:12
+msgid "AvtoZip Store placeholder"
+msgstr ""
+
+#: store/templates/store/index.html:13
+msgid "ProductList placeholder"
+msgstr ""
+
+#: templates/footer.html:3
+msgid "Footer placeholder"
+msgstr ""
+
+#: templates/header.html:4
+msgid "Header placeholder"
+msgstr ""
+
+#: templates/header.html:5
+msgid "Language"
+msgstr ""
+
+#: templates/index.html:5
+msgid "AvtoZip DashBoard placeholder"
+msgstr ""
+
+#: templates/index.html:7
+msgid "Store"
+msgstr ""
+
+#: templates/main.html:4
+msgid "AvtoZip Dashboard"
+msgstr ""

--- a/avtozip/locales/ru/LC_MESSAGES/django.po
+++ b/avtozip/locales/ru/LC_MESSAGES/django.po
@@ -1,0 +1,106 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-18 13:38+0000\n"
+"PO-Revision-Date: 2016-04-14 23:42+0000\n"
+"Last-Translator: b'  <>'\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
+"X-Translated-Using: django-rosetta 0.7.11\n"
+
+#: store/models.py:10
+msgid "Line1"
+msgstr "Дом, квартира"
+
+#: store/models.py:11
+msgid "Line2"
+msgstr "Корпус, этаж"
+
+#: store/models.py:12
+msgid "Street"
+msgstr "Улица"
+
+#: store/models.py:13
+msgid "City"
+msgstr "Город"
+
+#: store/models.py:14
+msgid "State"
+msgstr "Штат (Область)"
+
+#: store/models.py:15
+msgid "ZIP"
+msgstr "Индекс"
+
+#: store/models.py:16
+msgid "Country"
+msgstr "Страна"
+
+#: store/models.py:33 store/models.py:49 store/models.py:63
+msgid "Name"
+msgstr "Наименование"
+
+#: store/models.py:62
+msgid "Article"
+msgstr "Артикль"
+
+#: store/models.py:65
+msgid "Cost"
+msgstr "Стоимость"
+
+#: store/models.py:66
+msgid "Price"
+msgstr "Цена"
+
+#: store/models.py:67
+msgid "Count"
+msgstr "Количество"
+
+#: store/models.py:68
+msgid "Active"
+msgstr "Активный"
+
+#: store/templates/store/index.html:12
+msgid "AvtoZip Store placeholder"
+msgstr "Место для интернет-магазина AvtoZip"
+
+#: store/templates/store/index.html:13
+msgid "ProductList placeholder"
+msgstr "Место для списка продуктов"
+
+#: templates/footer.html:3
+msgid "Footer placeholder"
+msgstr "Место для \"ПОДВАЛА\""
+
+#: templates/header.html:4
+msgid "Header placeholder"
+msgstr "Место для \"ШАПКИ\""
+
+#: templates/header.html:5
+msgid "Language"
+msgstr "Язык"
+
+#: templates/index.html:5
+msgid "AvtoZip DashBoard placeholder"
+msgstr "Место для панели AvtoZip"
+
+#: templates/index.html:7
+msgid "Store"
+msgstr "Интернет-магазин"
+
+#: templates/main.html:4
+msgid "AvtoZip Dashboard"
+msgstr "Панель AvtoZip"

--- a/avtozip/store/management/__init__.py
+++ b/avtozip/store/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management package for Store application."""

--- a/avtozip/store/management/commands/__init__.py
+++ b/avtozip/store/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for Store application."""

--- a/avtozip/store/management/commands/checkmessages.py
+++ b/avtozip/store/management/commands/checkmessages.py
@@ -1,0 +1,52 @@
+"""Command to find untranslated entries in PO files."""
+
+import os
+import sys
+from collections import defaultdict
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+import polib
+
+
+class Command(BaseCommand):
+    """Checkmessages command implementation."""
+
+    help = 'Check for untranslated messages in all installed languages'
+
+    def add_arguments(self, parser):
+        """Add extra keywords to the command."""
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '-s', '--skip-locale', dest='skip_locales', action='append', default=settings.DEFAULT_SKIPPED_LOCALES,
+            help='Skip check for locales (default: "EN")',
+        )
+
+    def handle(self, *args, **options):
+        """Process all locales defined in settings and find untranslated entries."""
+        results = defaultdict(list)
+        for language_code, _ in settings.LANGUAGES:
+            if language_code in options['skip_locales']:
+                if options['verbosity'] > 1:
+                    self.stdout.write('Skipping locale "{}"'.format(language_code.upper()))
+                continue
+            for location in settings.LOCALE_PATHS:
+                filepath = '{0}/{1}/LC_MESSAGES/django.po'.format(location, language_code)
+                if os.path.isfile(filepath):
+                    untranslated = polib.pofile(filepath).untranslated_entries()
+                    for entry in untranslated:
+                        results[filepath].append('{1} # {0}'.format(entry.msgid, entry.linenum))
+                else:
+                    self.stdout.write('Locale folder does not exist: {0}'.format(filepath))
+                    sys.exit(1)
+        if results:
+            if options['verbosity'] > 0:
+                self.stdout.write('You have untranslated messages!')
+                for code, values in results.items():
+                    if options['verbosity'] > 1:
+                        self.stdout.write('{0}File {1}:'.format(' ' * 2, code))
+                        if options['verbosity'] > 2:
+                            for value in values:
+                                self.stdout.write('{0}{1}'.format(' ' * 4, value))
+            sys.exit(1)

--- a/avtozip/store/management/commands/makemessages.py
+++ b/avtozip/store/management/commands/makemessages.py
@@ -1,0 +1,24 @@
+"""Custom makemessages command to support additional keywords."""
+
+from django.conf import settings
+from django.core.management.commands import makemessages
+
+
+class Command(makemessages.Command):
+    """Custom makemessages command implementation."""
+
+    def add_arguments(self, parser):
+        """Add extra keywords to the command."""
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--extra-keyword', dest='xgettext_keywords', action='append', default=settings.DEFAULT_EXTRA_KEYWORDS,
+        )
+
+    def handle(self, *args, **options):
+        """Handle command and process extra arguments."""
+        xgettext_keywords = options.pop('xgettext_keywords')
+        if xgettext_keywords:
+            self.xgettext_options = (
+                makemessages.Command.xgettext_options + ['--keyword={0}'.format(kwd) for kwd in xgettext_keywords]
+            )
+        super(Command, self).handle(*args, **options)

--- a/avtozip/store/models.py
+++ b/avtozip/store/models.py
@@ -1,18 +1,19 @@
 """Store application models."""
 
 from django.db import models
+from django.utils.translation import ugettext_lazy as _ul
 
 
 class StoreAddress(models.Model):
     """Model for address of the store."""
 
-    line1 = models.CharField(max_length=100)
-    line2 = models.CharField(max_length=100, null=True, blank=True)
-    street = models.CharField(max_length=40)
-    city = models.CharField(max_length=40)
-    state = models.CharField(max_length=40, null=True, blank=True)
-    zip = models.CharField(max_length=20)
-    country = models.CharField(max_length=20)
+    line1 = models.CharField(max_length=100, verbose_name=_ul('Line1'))
+    line2 = models.CharField(max_length=100, null=True, blank=True, verbose_name=_ul('Line2'))
+    street = models.CharField(max_length=40, verbose_name=_ul('Street'))
+    city = models.CharField(max_length=40, verbose_name=_ul('City'))
+    state = models.CharField(max_length=40, null=True, blank=True, verbose_name=_ul('State'))
+    zip = models.CharField(max_length=20, verbose_name=_ul('ZIP'))
+    country = models.CharField(max_length=20, verbose_name=_ul('Country'))
 
     def __str__(self):
         """String representation of store address model."""
@@ -29,7 +30,7 @@ class StoreAddress(models.Model):
 class Store(models.Model):
     """Model for store."""
 
-    name = models.CharField(max_length=200)
+    name = models.CharField(max_length=200, verbose_name=_ul('Name'))
     address = models.ForeignKey('store.StoreAddress')
 
     def __str__(self):
@@ -45,7 +46,7 @@ class ProductCategory(models.Model):
     class Meta:
         verbose_name_plural = 'ProductCategories'
 
-    name = models.CharField(max_length=50)
+    name = models.CharField(max_length=50, verbose_name=_ul('Name'))
     parent = models.ForeignKey('store.ProductCategory', null=True, blank=True)
 
     def __str__(self):
@@ -58,13 +59,13 @@ class ProductCategory(models.Model):
 class Product(models.Model):
     """Model for product in the store."""
 
-    article = models.CharField(max_length=50)
-    name = models.CharField(max_length=200)
+    article = models.CharField(max_length=50, verbose_name=_ul('Article'))
+    name = models.CharField(max_length=200, verbose_name=_ul('Name'))
     category = models.ForeignKey(ProductCategory)
-    cost = models.DecimalField(max_digits=10, decimal_places=2)
-    price = models.DecimalField(max_digits=10, decimal_places=2)
-    count = models.DecimalField(max_digits=10, decimal_places=2)
-    is_active = models.BooleanField(default=False)
+    cost = models.DecimalField(max_digits=10, decimal_places=2, verbose_name=_ul('Cost'))
+    price = models.DecimalField(max_digits=10, decimal_places=2, verbose_name=_ul('Price'))
+    count = models.DecimalField(max_digits=10, decimal_places=2, verbose_name=_ul('Count'))
+    is_active = models.BooleanField(default=False, verbose_name=_ul('Active'))
     store = models.ForeignKey(Store)
 
     def __str__(self):

--- a/avtozip/store/templates/store/index.html
+++ b/avtozip/store/templates/store/index.html
@@ -1,4 +1,5 @@
 {% extends "store/main.html" %}
+{% load i18n %}
 
 {% block title %}AvtoZip Store{% endblock %}
 
@@ -8,8 +9,8 @@
 {% endblock %}
 
 {% block content %}
-  <h1>AvtoZip Store placeholder</h1>
-  <p>ProductList placeholder</p>
+  <h1>{% trans 'AvtoZip Store placeholder' %}</h1>
+  <p>{% trans 'ProductList placeholder' %}</p>
   <form method="post">
     {% csrf_token %}
     {{ formset.management_form }}

--- a/avtozip/store/tests/test_commands.py
+++ b/avtozip/store/tests/test_commands.py
@@ -1,0 +1,92 @@
+"""Module to test management commands."""
+
+import os
+import shutil
+from io import StringIO
+
+from django.conf import settings
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class MakeCheckTestCase(TestCase):
+    """Class to test `checkmesages` and `makemessages`."""
+
+    @classmethod
+    def setUpTestData(cls):  # NOQA
+        """sdfsfs."""
+        super(MakeCheckTestCase, cls).setUpTestData()
+        settings.LOCALE_PATHS = (
+            os.path.join(settings.BASE_DIR, 'test_locale'),
+        )
+
+    @classmethod
+    def tearDownClass(cls):  # NOQA
+        """sdfsf."""
+        super(MakeCheckTestCase, cls).tearDownClass()
+        shutil.rmtree(os.path.join(settings.BASE_DIR, 'test_locale'), ignore_errors=True)
+
+    def setUp(self):  # NOQA
+        super(MakeCheckTestCase, self).setUp()
+        shutil.rmtree(os.path.join(settings.BASE_DIR, 'test_locale'), ignore_errors=True)
+
+    def test_success_copied(self):
+        """Test successful check."""
+        out = StringIO()
+
+        shutil.copytree(os.path.join(settings.BASE_DIR, 'locales'), os.path.join(settings.BASE_DIR, 'test_locale'))
+        call_command('checkmessages', *'--verbosity 0'.split(), stdout=out)
+
+    def test_not_created(self):
+        """Test successful check2."""
+        out = StringIO()
+        with self.assertRaises(SystemExit) as cm:
+            call_command('checkmessages', *'--verbosity 0'.split(), stdout=out)
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn('Locale folder does not exist', out.getvalue())
+
+    def test_no_keywords(self):
+        """Test w/o makemessages keywords."""
+        out = StringIO()
+        settings.DEFAULT_EXTRA_KEYWORDS = []
+        call_command('makemessages', *'--locale en --locale ru --verbosity 0 --ignore env'.split(), stdout=out)
+        with self.assertRaises(SystemExit) as cm:
+            call_command('checkmessages', *'--verbosity 3'.split(), stdout=out)
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn('You have untranslated messages!', out.getvalue())
+
+    def test_failure_quite(self):
+        """Test failed check quite."""
+        out = StringIO()
+        call_command('makemessages', *'--locale en --locale ru --verbosity 0 --ignore env'.split(), stdout=out)
+        with self.assertRaises(SystemExit) as cm:
+            call_command('checkmessages', *'--verbosity 0'.split(), stdout=out)
+        self.assertEqual(cm.exception.code, 1)
+        self.assertEqual('', out.getvalue())
+
+    def test_failure_verbose_1(self):
+        """Test failed check verbose."""
+        out = StringIO()
+        call_command('makemessages', *'--locale en --locale ru --verbosity 0 --ignore env'.split(), stdout=out)
+        with self.assertRaises(SystemExit) as cm:
+            call_command('checkmessages', *'--verbosity 1'.split(), stdout=out)
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn('You have untranslated messages!', out.getvalue())
+
+    def test_failure_verbose_2(self):
+        """Test failed check verbose."""
+        out = StringIO()
+        call_command('makemessages', *'--locale en --locale ru --verbosity 0 --ignore env'.split(), stdout=out)
+        with self.assertRaises(SystemExit) as cm:
+            call_command('checkmessages', *'--verbosity 2'.split(), stdout=out)
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn('You have untranslated messages!', out.getvalue())
+
+    def test_failure_verbose_3(self):
+        """Test failed check verbose 3."""
+        out = StringIO()
+        call_command('makemessages', *'--locale en --locale ru --verbosity 0 --ignore env'.split(), stdout=out)
+        with self.assertRaises(SystemExit) as cm:
+            call_command('checkmessages', *'--verbosity 3'.split(), stdout=out)
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn('You have untranslated messages!', out.getvalue())

--- a/avtozip/templates/footer.html
+++ b/avtozip/templates/footer.html
@@ -1,1 +1,3 @@
-<footer>Footer placeholder</footer>
+{% load i18n %}
+
+<footer>{% trans 'Footer placeholder' %}</footer>

--- a/avtozip/templates/header.html
+++ b/avtozip/templates/header.html
@@ -1,1 +1,24 @@
-<header>Header placeholder</header>
+{% load i18n %}
+
+<header>
+  <div>
+    {% trans 'Header placeholder' %}
+  </div>
+  <div>
+      <form action="{% url 'set_language' %}" method="post">
+        {% csrf_token %}
+        {% trans 'Language' %}:
+        <input name="next" type="hidden" value="{{ redirect_to }}" />
+        <select name="language" onchange="this.form.submit()">
+          {% get_current_language as LANGUAGE_CODE %}
+          {% get_available_languages as LANGUAGES %}
+          {% get_language_info_list for LANGUAGES as languages %}
+          {% for language in languages %}
+            <option value="{{ language.code }}"{% if language.code == LANGUAGE_CODE %} selected="selected"{% endif %}>
+              {{ language.name_local }} ({{ language.code }})
+            </option>
+          {% endfor %}
+        </select>
+    </form>
+  </div>
+</header>

--- a/avtozip/templates/index.html
+++ b/avtozip/templates/index.html
@@ -1,8 +1,9 @@
 {% extends "main.html" %}
+{% load i18n %}
 
 {% block content %}
-  <h1>AvtoZip DashBoard placeholder</h1>
+  <h1>{% trans 'AvtoZip DashBoard placeholder' %}</h1>
   <li>
-    <ul><a href="{% url 'store:index' %}">Store</a></ul>
+    <ul><a href="{% url 'store:index' %}">{% trans 'Store' %}</a></ul>
   </li>
 {% endblock %}

--- a/avtozip/templates/main.html
+++ b/avtozip/templates/main.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}AvtoZip Dashboard{% endblock %}
+{% block title %}{% trans 'AvtoZip Dashboard' %}{% endblock %}
 
 {% block header %}
   {% include "header.html" %}

--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,8 @@ dependencies:
     - make install
 
 test:
+  pre:
+    - make messages
   override:
     - make test
   post:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ codecov==1.6.3
 coveralls==1.1
 django-autofixture==0.12.0
 django-debug-toolbar==1.4
+django-rosetta==0.7.11
 flake8-blind-except==0.1.0
 flake8-deprecated==1.0
 flake8-import-order==0.7
@@ -14,3 +15,4 @@ flake8-quotes==0.2.4
 flake8-strict==0.1.2
 flake8-tidy-imports==1.0.0
 pep8-naming==0.3.3
+tblib==1.3.0


### PR DESCRIPTION
Added two management commands:
- makemessages (to update keywords)
- checkmessages (to check untranslated messages)

Added translation to templates and models
Added tblib and rosetta to our dev requirements to support traceback in parallel test execution and to support translation in admin page
Added `messages` target to makefile to generate and compile translation
Added LocaleMiddleware for translation and updated all locale related settings

@zitoss , @youshal  please take a look

Fixes #43
