### PR TITLE
Issue 57 - ProductList POST does not render extra form after successful save

### DIFF
--- a/avtozip/store/views.py
+++ b/avtozip/store/views.py
@@ -12,7 +12,8 @@ def index_view(request):
         formset = ProductFormSet(request.POST)
         if formset.is_valid():
             formset.save()
-    else:
+
+    if request.method != 'POST' or formset.is_valid():
         res = ProductResource()
         request_bundle = res.build_bundle(request=request)
         formset = ProductFormSet(queryset=res.obj_get_list(request_bundle))


### PR DESCRIPTION
corrected POST handling of Product List. If request isn't `POST` or transmitted data is valid, we recreate formset. Thus we append extra line into formset for new product creation.

@sshishov, @youshal  please check the solution.

Fixed #57
