### PR TITLE
Issue 64 - Apply all changes in model to initial migration before first release

### DIFF
--- a/avtozip/locales/en/LC_MESSAGES/django.po
+++ b/avtozip/locales/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-24 09:54+0000\n"
+"POT-Creation-Date: 2016-04-24 20:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -61,12 +61,16 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: store/models.py:64
-msgid "Article"
+#: store/models.py:36
+msgid "Address"
 msgstr ""
 
-#: store/models.py:66
+#: store/models.py:52 store/models.py:66
 msgid "Category"
+msgstr ""
+
+#: store/models.py:64
+msgid "Article"
 msgstr ""
 
 #: store/models.py:67

--- a/avtozip/locales/ru/LC_MESSAGES/django.po
+++ b/avtozip/locales/ru/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-24 09:54+0000\n"
+"POT-Creation-Date: 2016-04-24 20:44+0000\n"
 "PO-Revision-Date: 2016-04-14 23:42+0000\n"
 "Last-Translator: b'  <>'\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -65,13 +65,17 @@ msgstr "Страна"
 msgid "Name"
 msgstr "Наименование"
 
+#: store/models.py:36
+msgid "Address"
+msgstr "Адрес"
+
+#: store/models.py:52 store/models.py:66
+msgid "Category"
+msgstr "Категория"
+
 #: store/models.py:64
 msgid "Article"
 msgstr "Артикул"
-
-#: store/models.py:66
-msgid "Category"
-msgstr "Категория"
 
 #: store/models.py:67
 msgid "Cost"

--- a/avtozip/store/migrations/0001_initial.py
+++ b/avtozip/store/migrations/0001_initial.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import django.db.models.deletion
 
+from store import fields as custom_fields
+
 
 class Migration(migrations.Migration):
 
@@ -18,20 +20,21 @@ class Migration(migrations.Migration):
             name='Product',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('article', models.CharField(max_length=50)),
-                ('name', models.CharField(max_length=200)),
-                ('cost', models.DecimalField(decimal_places=2, max_digits=10)),
-                ('price', models.DecimalField(decimal_places=2, max_digits=10)),
-                ('count', models.DecimalField(decimal_places=2, max_digits=10)),
-                ('is_active', models.BooleanField(default=False)),
+                ('article', custom_fields.ArticleField(max_length=50, verbose_name='Article')),
+                ('name', models.CharField(max_length=200, verbose_name='Name')),
+                ('cost', custom_fields.PositiveDecimalField(decimal_places=2, max_digits=10, verbose_name='Cost')),
+                ('price', custom_fields.PositiveDecimalField(decimal_places=2, max_digits=10, verbose_name='Price')),
+                ('count', custom_fields.PositiveDecimalField(decimal_places=2, max_digits=10, verbose_name='Count')),
+                ('is_active', models.BooleanField(default=True, verbose_name='Active')),
             ],
         ),
         migrations.CreateModel(
             name='ProductCategory',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=50)),
-                ('parent', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, to='store.ProductCategory')),
+                ('name', models.CharField(max_length=50, verbose_name='Name')),
+                ('parent', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE,
+                                             to='store.ProductCategory', verbose_name='Category')),
             ],
             options={
                 'verbose_name_plural': 'ProductCategories',
@@ -41,35 +44,38 @@ class Migration(migrations.Migration):
             name='Store',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=200)),
+                ('name', models.CharField(max_length=200, verbose_name='Name')),
             ],
         ),
         migrations.CreateModel(
             name='StoreAddress',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('line1', models.CharField(max_length=100)),
-                ('line2', models.CharField(blank=True, max_length=100, null=True)),
-                ('street', models.CharField(max_length=40)),
-                ('city', models.CharField(max_length=40)),
-                ('state', models.CharField(blank=True, max_length=40, null=True)),
-                ('zip', models.CharField(max_length=20)),
-                ('country', models.CharField(max_length=20)),
+                ('line1', models.CharField(max_length=100, verbose_name='Line1')),
+                ('line2', models.CharField(blank=True, max_length=100, null=True, verbose_name='Line2')),
+                ('street', models.CharField(max_length=40, verbose_name='Street')),
+                ('city', models.CharField(max_length=40, verbose_name='City')),
+                ('state', models.CharField(blank=True, max_length=40, null=True, verbose_name='State')),
+                ('zip', models.CharField(max_length=20, verbose_name='ZIP')),
+                ('country', models.CharField(max_length=20, verbose_name='Country')),
             ],
         ),
         migrations.AddField(
             model_name='store',
             name='address',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='store.StoreAddress'),
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='store.StoreAddress',
+                                    verbose_name='Address'),
         ),
         migrations.AddField(
             model_name='product',
             name='category',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='store.ProductCategory'),
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='store.ProductCategory',
+                                    verbose_name='Category'),
         ),
         migrations.AddField(
             model_name='product',
             name='store',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='store.Store'),
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='store.Store',
+                                    verbose_name='Store'),
         ),
     ]

--- a/avtozip/store/models.py
+++ b/avtozip/store/models.py
@@ -33,7 +33,7 @@ class Store(models.Model):
     """Model for store."""
 
     name = models.CharField(max_length=200, verbose_name=_ul('Name'))
-    address = models.ForeignKey('store.StoreAddress')
+    address = models.ForeignKey('store.StoreAddress', verbose_name=_ul('Address'))
 
     def __str__(self):
         """String representation of store model."""
@@ -49,7 +49,7 @@ class ProductCategory(models.Model):
         verbose_name_plural = 'ProductCategories'
 
     name = models.CharField(max_length=50, verbose_name=_ul('Name'))
-    parent = models.ForeignKey('store.ProductCategory', null=True, blank=True)
+    parent = models.ForeignKey('store.ProductCategory', null=True, blank=True, verbose_name=_ul('Category'))
 
     def __str__(self):
         """String representation of product category model."""
@@ -67,7 +67,7 @@ class Product(models.Model):
     cost = custom_fields.PositiveDecimalField(verbose_name=_ul('Cost'))
     price = custom_fields.PositiveDecimalField(verbose_name=_ul('Price'))
     count = custom_fields.PositiveDecimalField(verbose_name=_ul('Count'))
-    is_active = models.BooleanField(default=False, verbose_name=_ul('Active'))
+    is_active = models.BooleanField(default=True, verbose_name=_ul('Active'))
     store = models.ForeignKey(Store, verbose_name=_ul('Store'))
 
     def __str__(self):

--- a/avtozip/store/tests/test_views.py
+++ b/avtozip/store/tests/test_views.py
@@ -33,6 +33,7 @@ class ProductListViewTestCase(test.TestCase):
             'form-0-price': self.product.price,
             'form-0-count': self.product.count,
             'form-0-store': self.product.store_id,
+            'form-0-is_active': self.product.is_active,
             'form-1-id': '',
             'form-1-article': '',
             'form-1-name': '',
@@ -41,6 +42,7 @@ class ProductListViewTestCase(test.TestCase):
             'form-1-price': '',
             'form-1-count': '',
             'form-1-store': '',
+            'form-1-is_active': 'on',
             'form-TOTAL_FORMS': '2',
             'form-INITIAL_FORMS': '1',
         }
@@ -61,6 +63,7 @@ class ProductListViewTestCase(test.TestCase):
             'form-0-price': new_product.price,
             'form-0-count': new_product.count,
             'form-0-store': new_product.store_id,
+            'form-0-is_active': new_product.is_active,
             'form-1-id': '',
             'form-1-article': '',
             'form-1-name': '',
@@ -69,6 +72,7 @@ class ProductListViewTestCase(test.TestCase):
             'form-1-price': '',
             'form-1-count': '',
             'form-1-store': '',
+            'form-1-is_active': 'on',
             'form-TOTAL_FORMS': '2',
             'form-INITIAL_FORMS': '1',
         }
@@ -92,6 +96,7 @@ class ProductListViewTestCase(test.TestCase):
             'form-0-price': self.product.price,
             'form-0-count': self.product.count,
             'form-0-store': self.product.store_id,
+            'form-0-is_active': self.product.is_active,
             'form-1-id': '',
             'form-1-article': new_product.article,
             'form-1-name': new_product.name,
@@ -100,6 +105,7 @@ class ProductListViewTestCase(test.TestCase):
             'form-1-price': new_product.price,
             'form-1-count': new_product.count,
             'form-1-store': new_product.store_id,
+            'form-1-is_active': new_product.is_active,
             'form-TOTAL_FORMS': '2',
             'form-INITIAL_FORMS': '1',
         }
@@ -124,6 +130,7 @@ class ProductListViewTestCase(test.TestCase):
             'form-0-price': new_product.price,
             'form-0-count': new_product.count,
             'form-0-store': new_product.store_id,
+            'form-0-is_active': new_product.is_active,
             'form-1-id': '',
             'form-1-article': '',
             'form-1-name': '',
@@ -132,6 +139,7 @@ class ProductListViewTestCase(test.TestCase):
             'form-1-price': '',
             'form-1-count': '',
             'form-1-store': '',
+            'form-1-is_active': 'on',
             'form-TOTAL_FORMS': '2',
             'form-INITIAL_FORMS': '1',
         }


### PR DESCRIPTION
Added missed translation for address (inside store) and category (inside category)
Applied migrations to initial (using makemigrations and move changes)
Updated tests and changed default value fo `is_active` product's field default value to `True`

@zitoss , @youshal  please take a look

Fixes #64
