### PR TITLE
Issue 67 - Add support to communicate with front-end app

### DIFF
--- a/avtozip/avtozip/settings/development.py
+++ b/avtozip/avtozip/settings/development.py
@@ -12,9 +12,7 @@ inject_settings('avtozip.settings.production', locals())
 # Debug settings
 DEBUG = True
 ALLOWED_HOSTS = []
-
-# Django TastyPie settings
-TASTYPIE_DEFAULT_FORMATS = ['json']
+CORS_ORIGIN_ALLOW_ALL = True
 
 # Additional applications
 INSTALLED_APPS += [

--- a/avtozip/avtozip/settings/production.py
+++ b/avtozip/avtozip/settings/production.py
@@ -12,7 +12,14 @@ SECRET_KEY = 'kknfrz7qvs%fr(yfui8iuds0pk%a2a0xbux1+i%54eb$^1rf^h'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
-ALLOWED_HOSTS = ['127.0.0.1']
+ALLOWED_HOSTS = [
+    '127.0.0.1',
+    'localhost'
+]
+CORS_ORIGIN_WHITELIST = [
+    '127.0.0.1:8014'
+    'localhost:8014'
+]
 
 # Application definition
 INSTALLED_APPS = [
@@ -23,6 +30,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
+    'corsheaders',
     'django_extensions',
     'httpproxy',
     'tastypie',
@@ -32,6 +40,7 @@ INSTALLED_APPS = [
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/avtozip/webstore/api/tests/test_base_resource.py
+++ b/avtozip/webstore/api/tests/test_base_resource.py
@@ -6,6 +6,62 @@ from django.test import TestCase
 from tastypie import http
 
 
+class ResponseFormatTestCase(TestCase):
+    """JSON/XML format with different request structure."""
+
+    def test_no_format(self):
+        """No format provided, JSON by default."""
+        response = self.client.get(
+            reverse('api_dispatch_list', kwargs={'resource_name': 'product', 'api_name': 'webstore_v1'}),
+        )
+        self.assertEqual(response.status_code, http.HttpResponse.status_code)
+        self.assertIn('application/json', response.get('Content-Type'))
+
+    def test_json_format_keyword(self):
+        """JSON format provided using `?format=json`."""
+        response = self.client.get(
+            '{}?format={}'.format(
+                reverse('api_dispatch_list', kwargs={'resource_name': 'product', 'api_name': 'webstore_v1'}),
+                'json',
+            ),
+        )
+        self.assertEqual(response.status_code, http.HttpResponse.status_code)
+        self.assertIn('application/json', response.get('Content-Type'))
+
+    def test_xml_format_keyword(self):
+        """XML format provided using `?format=xml`."""
+        response = self.client.get(
+            '{}?format={}'.format(
+                reverse('api_dispatch_list', kwargs={'resource_name': 'product', 'api_name': 'webstore_v1'}),
+                'xml',
+            ),
+        )
+        self.assertEqual(response.status_code, http.HttpResponse.status_code)
+        self.assertIn('application/xml', response.get('Content-Type'))
+
+    def test_json_format_appendix(self):
+        """JSON format provided using `<resource>.json`."""
+        response = self.client.get(
+            reverse(
+                viewname='api_dispatch_list',
+                kwargs={'resource_name': 'product', 'api_name': 'webstore_v1', 'format': 'json'},
+            ),
+        )
+        self.assertEqual(response.status_code, http.HttpResponse.status_code)
+        self.assertIn('application/json', response.get('Content-Type'))
+
+    def test_xml_format_appendix(self):
+        """XML format provided using `<resource>.xml`."""
+        response = self.client.get(
+            reverse(
+                viewname='api_dispatch_list',
+                kwargs={'resource_name': 'product', 'api_name': 'webstore_v1', 'format': 'xml'},
+            ),
+        )
+        self.assertEqual(response.status_code, http.HttpResponse.status_code)
+        self.assertIn('application/xml', response.get('Content-Type'))
+
+
 class GetSchemaTestCase(TestCase):
     """Forbidden schema access for any resource."""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
+defusedxml==0.4.1
 dj-database-url==0.4.0
 Django==1.9.4
+django-cors-headers==1.1.0
 django-extensions==1.6.1
 django-http-proxy==0.4.3
 django-tastypie==0.13.3
+lxml==3.6.0
 psycopg2==2.6.1


### PR DESCRIPTION
Added 3rd party lib to support CORS request using easy setting configuration

Applied rules:
- production (support CORS only safe entry `localhost:8014` and its alias)
- development (support any CORS destination)

Removed `TASTYPIE_DEFAULT_FORMATS` and applied technique with appendix of format like `<resource>.<format>`

Added tests to cover newly added functionality

Updated requirements:
- defusedxml (to support XML response format)
- lxml (to support XML response format)
- django-cors-headers

@zitoss , @youshal  please take a look

@Gosha2015 be notified about these changes

Fixes #67
